### PR TITLE
Falso Positivo - Sinalizando onde aplicar teste

### DIFF
--- a/tests/createCrush.test.js
+++ b/tests/createCrush.test.js
@@ -52,6 +52,8 @@ describe('2 - Crie o endpoint POST /crush', () => {
           })
           .expect('status', 201)
           .then((responseCreate) => {
+            // aqui deveria ter algo para verificar que o registro foi inserido no arquivo `crush.json`
+
             const { json } = responseCreate;
             expect(json).toEqual(postCrushMock);
           });

--- a/tests/deleteCrush.test.js
+++ b/tests/deleteCrush.test.js
@@ -49,6 +49,7 @@ describe('6 - Crie o endpoint DELETE /crush/:id', () => {
           })
           .expect('status', 201)
           .then((responseCreate) => {
+            // aqui deveria ter algo para verificar que o registro foi removido no arquivo `crush.json`
             const { body } = responseCreate;
             resultCrush = JSON.parse(body);
           });

--- a/tests/editCrush.test.js
+++ b/tests/editCrush.test.js
@@ -49,6 +49,7 @@ describe('5 - Crie o endpoint PUT /crush/:id', () => {
           })
           .expect('status', 201)
           .then((responseCreate) => {
+            // aqui deveria ter algo para verificar que o registro foi atualizado no arquivo `crush.json`
             const { body } = responseCreate;
             resultCrush = JSON.parse(body);
           });


### PR DESCRIPTION
Algumas pessoas estudantes na T6 perceberam um problema nos testes do projeto. Os requisitos 4, 5 e 6, respectivamente as operações de cadastrar / atualizar / remover, só verificam se a resposta está de acordo com o esperado, mas não validam se a operação de escrita foi realmente feita. Assim, algumas pessoas podem passar pelo projeto sem escrever a lógica para manipular o arquivo crush.json.